### PR TITLE
fixed bug where message notifications wouldn't route

### DIFF
--- a/client/src/app/members/member-detail/member-detail.component.html
+++ b/client/src/app/members/member-detail/member-detail.component.html
@@ -34,21 +34,21 @@
     </div>
     <div class="col-8">
         <tabset class="member-tabset" #memberTabs>
-            <tab heading="About {{member.knownAs}}" (selectTab)="onTabActivated($event)">
+            <tab heading="About {{member.knownAs}}" (selectTab)="onTabActivated($event, 0)">
                 <h4>Description</h4>
                 <p>{{member.introduction}}</p>
                 <h4>Looking for</h4>
                 <p>{{member.lookingFor}}</p>
             </tab>
-            <tab heading="Interests" (selectTab)="onTabActivated($event)">
+            <tab heading="Interests" (selectTab)="onTabActivated($event, 1)">
                 <h4>Interests</h4>
                 <p>{{member.interests}}</p>
             </tab>
-            <tab heading="Photos" (selectTab)="onTabActivated($event)">
+            <tab heading="Photos" (selectTab)="onTabActivated($event, 2)">
                 <ngx-gallery [options]="galleryOptions" [images]="galleryImages" style="display: inline-block; margin-bottom: 20px;"></ngx-gallery>
                 <p>Photos will go here</p>
             </tab>
-            <tab heading="Messages" (selectTab)="onTabActivated($event)">
+            <tab heading="Messages" (selectTab)="onTabActivated($event, 3)">
                 <app-member-messages [username]="member.username"></app-member-messages>
             </tab>
         </tabset>

--- a/client/src/app/members/member-detail/member-detail.component.ts
+++ b/client/src/app/members/member-detail/member-detail.component.ts
@@ -73,10 +73,20 @@ export class MemberDetailComponent implements OnInit, OnDestroy {
   }
 
   selectTab(tabId: number) {
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: { tab: tabId }
+    });
+
     this.memberTabs.tabs[tabId].active = true;
   }
 
-  onTabActivated(data: TabDirective) {
+  onTabActivated(data: TabDirective, tabId: number) {
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: { tab: tabId }
+    });
+    
     this.activeTab = data;
     if(this.activeTab.heading === 'Messages' && this.messages.length === 0) {
       this.messageService.createHubConnection(this.user, this.member.username);


### PR DESCRIPTION
Imagine: You're a user, you get a notification of a message. You click on it. It's your friend Jessica, who has shared with you a cool meme. You click on the toastr notification and it navigates you to /members/jessica?tab=3 - the chat window with Jessica - and you reply "lol". You navigate off the chat window, clicking on the Photos tab to see what projects Jessica has been working on lately. You get another toastr notification: Jessica has responded to your message! But when you go to click on it, **nothing happens**. You are stunned. You have to _manually_ click on the Messages tab. But in the five seconds you lost in not responding to Jessica's message ("is that all ur going to say really"), Jessica has lost something too - her faith in you as a friend.

Fixed this problem.

(clicking to other member-detail tabs wouldn't change the route in the url, so if you are on the Messages page and go to a different tab, when you click on a new messages notification link, it doesn't change your tab because the router doesn't detect any changes in your route)