### PR TITLE
fix issue: navigating back from member-detail

### DIFF
--- a/client/src/app/members/member-detail/member-detail.component.ts
+++ b/client/src/app/members/member-detail/member-detail.component.ts
@@ -73,11 +73,6 @@ export class MemberDetailComponent implements OnInit, OnDestroy {
   }
 
   selectTab(tabId: number) {
-    this.router.navigate([], {
-      relativeTo: this.route,
-      queryParams: { tab: tabId }
-    });
-
     this.memberTabs.tabs[tabId].active = true;
   }
 


### PR DESCRIPTION
Due to previous hotfix, on entering the member-detail page, it would route you to ?tab=0 multiple times, so you couldn't leave with the "back" button. Removed code manually setting route upon entering the member-detail page.
